### PR TITLE
docs: fix and clarify `npm pack` mention

The text is taken from @bluwy comment: https://github.com/vitejs/vite/issues/5819#issuecomment-982713653

fixes #5819
fixes #6980 (#6)

### DIFF
--- a/docs/guide/dep-pre-bundling.md
+++ b/docs/guide/dep-pre-bundling.md
@@ -40,7 +40,7 @@ In a monorepo setup, a dependency may be a linked package from the same repo. Vi
 
 ::: warning Note
 Linked dependencies might not work properly in the final build due to differences in dependency resolution.
-Use `npm package` instead for all local dependencies to avoid issues in the final bundle.
+Use `npm pack` instead for all local dependencies to avoid issues in the final bundle. (The `npm pack` is only ever needed when the linked source code or package only exports CJS code. If it exports ESM code, then it is not needed.)
 :::
 
 ## Customizing the Behavior


### PR DESCRIPTION
resolves #6
Cherry picked from https://github.com/vitejs/vite/commit/55589db970c9abf0f67538271c9dce40ace9f5ad