### PR TITLE
docs: clarify deprecated exports key end with `/`

Co-authored-by: Bjorn Lu <bjornlu.dev@gmail.com> (#37)

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -241,6 +241,10 @@ export default defineConfig(({ command, mode }) => {
 
   Vite has a list of "allowed conditions" and will match the first condition that is in the allowed list. The default allowed conditions are: `import`, `module`, `browser`, `default`, and `production/development` based on current mode. The `resolve.conditions` config option allows specifying additional allowed conditions.
 
+  :::warning Resolving subpath exports
+  Export keys ending with "/" is deprecated by Node and may not work well. Please contact the package author to use [`*` subpath patterns](https://nodejs.org/api/packages.html#package-entry-points) instead.
+  :::
+
 ### resolve.mainFields
 
 - **Type:** `string[]`


### PR DESCRIPTION
resolves #37
Cherry picked from https://github.com/vitejs/vite/commit/799880758f589b7ea96d6db9cd1ea163421649f8