### PR TITLE
docs: vite only replace `__dirname`, `__filename`, `import.meta.url` in cjs

Co-authored-by: Bjorn Lu <bjornlu.dev@gmail.com> (#43)

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -27,13 +27,16 @@ You can also explicitly specify a config file to use with the `--config` CLI opt
 vite --config my-config.js
 ```
 
-Note that Vite will replace `__filename`, `__dirname`, and `import.meta.url`. Using these as variable names will result in an error:
+::: tip NOTE
+Vite will replace `__filename`, `__dirname`, and `import.meta.url` in **CommonJS** and **TypeScript** config files. Using these as variable names will result in an error:
 
 ```js
 const __filename = "value"
 // will be transformed to
 const "path/vite.config.js" = "value"
 ```
+
+:::
 
 ### Config Intellisense
 


### PR DESCRIPTION
resolves #43
Cherry picked from https://github.com/vitejs/vite/commit/f44859379277b7a3e99529be275022733dc69ef1