### PR TITLE
docs: mention `process.env` for config env vars (#69)

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -101,7 +101,9 @@ export default defineConfig(async ({ command, mode }) => {
 
 ### Environment Variables
 
-Vite doesn't load `.env` files by default as the files to load can only be determined after evaluating the Vite config, for example, the `root` and `envDir` options affects the loading behaviour. However, you can use the exported `loadEnv` helper to load the specific `.env` file if needed.
+Environmental Variables can be obtained from `process.env` as usual.
+
+Note that Vite doesn't load `.env` files by default as the files to load can only be determined after evaluating the Vite config, for example, the `root` and `envDir` options affects the loading behaviour. However, you can use the exported `loadEnv` helper to load the specific `.env` file if needed.
 
 ```js
 import { defineConfig, loadEnv } from 'vite'


### PR DESCRIPTION
resolves #69
Cherry picked from https://github.com/vitejs/vite/commit/434bb5c05bce8a376bde50100a1466072d5e3624