### PR TITLE
docs: import.meta.url is replaced even if ESM (#73)

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -28,7 +28,7 @@ vite --config my-config.js
 ```
 
 ::: tip NOTE
-Vite will replace `__filename`, `__dirname`, and `import.meta.url` in **CommonJS** and **TypeScript** config files. Using these as variable names will result in an error:
+Vite will replace `__filename`, `__dirname`, and `import.meta.url` in config files and its deps. Using these as variable names will result in an error:
 
 ```js
 const __filename = "value"


### PR DESCRIPTION
resolves #73
Cherry picked from https://github.com/vitejs/vite/commit/6198911faeee3b915fc0d4ff24fbb918f3e1d558