### PR TITLE
docs: make it clear that array format can only be used for inline postcss config (#76)

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -304,7 +304,11 @@ export default defineConfig(({ command, mode }) => {
 
 - **Type:** `string | (postcss.ProcessOptions & { plugins?: postcss.Plugin[] })`
 
-  Inline PostCSS config (expects the same format as `postcss.config.js`), or a custom directory to search PostCSS config from (default is project root). The search is done using [postcss-load-config](https://github.com/postcss/postcss-load-config) and only the supported config file names are loaded.
+  Inline PostCSS config or a custom directory to search PostCSS config from (default is project root).
+
+  For inline PostCSS config, it expects the same format as `postcss.config.js`. But for `plugins` property, only [array format](https://github.com/postcss/postcss-load-config/blob/main/README.md#array) can be used.
+
+  The search is done using [postcss-load-config](https://github.com/postcss/postcss-load-config) and only the supported config file names are loaded.
 
   Note if an inline config is provided, Vite will not search for other PostCSS config sources.
 


### PR DESCRIPTION
resolves #76
Cherry picked from https://github.com/vitejs/vite/commit/9c6501d9c363eaa3c1e7708d531fb2a92b633db6