### PR TITLE
docs: typo (#104)

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -42,7 +42,7 @@ $ npm run preview
 
 The `vite preview` command will boot up local static web server that serves the files from `dist` at http://localhost:5000. It's an easy way to check if the production build looks OK in your local environment.
 
-You may configure the port of the server py passing `--port` flag as an argument.
+You may configure the port of the server by passing `--port` flag as an argument.
 
 ```json
 {


### PR DESCRIPTION
resolves #104
Cherry picked from https://github.com/vitejs/vite/commit/02ff4811f10c2a6c7af75b2641b1439e92ed4b8a